### PR TITLE
Small change to assertRedirects so it works with absolute URLs

### DIFF
--- a/gaetestbed/web.py
+++ b/gaetestbed/web.py
@@ -61,15 +61,13 @@ class WebTestCase(BaseTestCase):
         error = 'Response did not redirect (status code was %i).' % response.status_int
         self.assertTrue(response.status_int in (301, 302), error)
         if to is not None:
-            if to.startswith("http"):
-                expected_redirect = to
-            else:
-                expected_redirect = 'http://localhost%s' % to
+            if not to.startswith("http"):
+                to = 'http://localhost%s' % to
             
             error = 'Response redirected, but went to %s instead of %s' % (
-                response.location, expected_redirect
+                response.location, to
             )
-            self.assertEqual(response.location, expected_redirect, error)
+            self.assertEqual(response.location, to, error)
     
     def assertOK(self, response):
         """

--- a/gaetestbed/web.py
+++ b/gaetestbed/web.py
@@ -61,10 +61,15 @@ class WebTestCase(BaseTestCase):
         error = 'Response did not redirect (status code was %i).' % response.status_int
         self.assertTrue(response.status_int in (301, 302), error)
         if to is not None:
+            if to.startswith("http"):
+                expected_redirect = to
+            else:
+                expected_redirect = 'http://localhost%s' % to
+            
             error = 'Response redirected, but went to %s instead of %s' % (
-                response.location, to
+                response.location, expected_redirect
             )
-            self.assertEqual(response.location, 'http://localhost%s' % to, error)
+            self.assertEqual(response.location, expected_redirect, error)
     
     def assertOK(self, response):
         """


### PR DESCRIPTION
Hi jgeewax,

I made a small change to fix a problem with assertRedirects which I have run into a couple of times. Before this change, if you want to test a redirect off-site the test fails. Worse, the message is very confusing because it says "Response redirected but went to http://foobar.com/ instead of http://foobar.com/". 

I just changed it to check if the "to" parameter starts with "http", and leave it alone if if it does. If it doesn't, it is prepend with http://localhost as before.

I would appreciate it if you would take the time to review and incorporate this patch so I don't have to maintain a fork. 

Thanks,

Luke Francl
